### PR TITLE
Minor formatting changes to Lexer document

### DIFF
--- a/Lexer.md
+++ b/Lexer.md
@@ -17,9 +17,9 @@ In order for a character to be considered valid, it must be mappable to one or m
 
 Note: in the following table, possible values for each single-token-type are expressed in the form of a regular expression pattern.
 
-* Character - /[A-Za-z]/
-* Number - /[\d]+/
-* String - /[\"|\']{1}([\w]+)[\"|\']{1}/
+* Character - `/[A-Za-z]/`
+* Number - `/[\d]+/`
+* String - `/[\"|\']{1}([\w]+)[\"|\']{1}/`
 
 If a character cannot be mapped to at least one of the previously documented single-token-types, it is considered to be an invalid character.
 
@@ -58,28 +58,30 @@ Given our sample program, the first step of the lexer might output something lik
 
 If a character is considered to be valid, it will then be converted to a single-token.
 A single-token is not much more than a character, with a
-If a character is considered to be valid (see “Validation of characters”), it will then be converted to a single-token.
+If a character is considered to be valid (see "Validation of characters"), it will then be converted to a single-token.
 A single-token, is not much more than a character, with an attribute to describe its single-token-type.
-If a single-token for the ‘a’ character, was to be expressed using the JSON format, it might look somewhat like follows:
+If a single-token for the 'a' character, was to be expressed using the JSON format, it might look somewhat like follows:
 
-    {
-        “type”: “Character”,
-        “value”:  ‘a’
-    }
+```json
+{
+    "type": "Character",
+    "value": 'a'
+}
+```
 
 Please note the inclusion of whitespace tokens in the above example. These tokens are important as they are used to help the lexer (in step 2) determine where a potential combined-token starts and ends.
 
 ### Building combined tokens
 
-A combined-token, consists of one or more single-tokens, and an attribute to describe the combined-token’s type.
+A combined-token, consists of one or more single-tokens, and an attribute to describe the combined-token's type.
 
 Generally speaking, in order for a set of single-tokens to be compiled into one combined-token, each of their single-token-types, needs to match.
 
-To build a combined-token, the lexer will iterate through the previously generated list of single-tokens, and check each single-token’s type. If the current single-token has a single-token-type which matches that of the previous single-token, the lexer will combine the previous and current single-tokens, into one combined-token.
+To build a combined-token, the lexer will iterate through the previously generated list of single-tokens, and check each single-token's type. If the current single-token has a single-token-type which matches that of the previous single-token, the lexer will combine the previous and current single-tokens, into one combined-token.
 
-Combining of single-tokens that have matching types (or a “combining session”), will stop once a whitespace token is encountered.
+Combining of single-tokens that have matching types (or a "combining session"), will stop once a whitespace token is encountered.
 
-Once a “combining session” has stopped, the combined-token that was built, will then be evaluated to determine its combined-token-type.
+Once a "combining session" has stopped, the combined-token that was built, will then be evaluated to determine its combined-token-type.
 
 A list of combined-token-types, as well as their possible values, can be found below:
 


### PR DESCRIPTION
Got rid of smart-quotes and turned example token into JSON-formatted code block.

-- Brynden Bielefeld (gigabyte.giant@gmail.com)